### PR TITLE
Bugfix 103: Ignore `styled.css` elements in snapshots script

### DIFF
--- a/bin/generateSnapshots/extractor.js
+++ b/bin/generateSnapshots/extractor.js
@@ -1,3 +1,4 @@
+import { size } from 'lodash'
 /*
  * Returns an array of strings containing every props.
  */
@@ -17,3 +18,12 @@ export const extractValue = prop => prop.match(/PropTypes.[\S]+/g)
  * Returns children prop's value.
  */
 export const extractChildrenValue = rawValue => rawValue.match(/[^{"}]+/g)
+
+/*
+ * Returns the number of components & styled-components in the file.
+ */
+export const getNumberOfComponents = content => {
+  const classes = content.match(/extends (Component|PureComponent)/g)
+  const styled = content.match(/=\s?styled/g)
+  return size(classes) + size(styled)
+}

--- a/bin/generateSnapshots/index.js
+++ b/bin/generateSnapshots/index.js
@@ -5,7 +5,13 @@ import glob from 'glob'
 
 import SnapshotComponent from './SnapshotComponent'
 import { mockProp } from './mocks'
-import { extractProps, extractKey, extractChildrenValue, extractValue } from './extractor'
+import {
+  extractProps,
+  extractKey,
+  extractChildrenValue,
+  extractValue,
+  getNumberOfComponents,
+} from './extractor'
 
 /*
  * Folders to ignore.
@@ -128,7 +134,7 @@ glob(`${componentsDir}/**/!(${ignoreList})/!(*.native).js`, (err, files) => {
         )
     try {
       const fileContent = fs.readFileSync(file, 'utf-8')
-      if (fileContent.includes(ignoreAnnotation)) {
+      if (fileContent.includes(ignoreAnnotation) || getNumberOfComponents(fileContent) < 1) {
         logComponentSkipped(snapshotComponent.getName())
         return
       }


### PR DESCRIPTION
- Add `styled.css` elements on ignore list of snapshots

Issue: [#103](https://github.com/attineos/atti-components/issues/103)